### PR TITLE
Update grapDLCount: 解决整理资料库时出现Wide character的问题

### DIFF
--- a/grapDLCount
+++ b/grapDLCount
@@ -64,6 +64,7 @@ foreach $i ( 0..$#urls ){
             $result{'title'} = $_->find('img')->attr('title');
             # **** title will block by updateDLSilteDB from update
             $result{'text'} = $_->find('dd.work_text')->text();
+            $result{'text'} =~ s/…/.../;
             $result{'image'} = $image;
             #Encode::_utf8_on($result{'title'});
             #Encode::_utf8_on($result{'text'});


### PR DESCRIPTION
在将某些资源导入资料库时，终端如下所示报错：
`----- move to /Users/XXXXX/voice1808251341`
`----- unfoldDLSiteFile`
`----- grapDLCount`
`Wide character at /Library/Perl/5.18/darwin-thread-multi-2level/Encode.pm line 296.`
`----- buildDLSite`

看了下err.log中显示：
`malformed JSON string, neither array, object, number, string or atom, at character offset 0 (before "(end of string)") at ./buildDLSite line 41.`
发现是new_works.json中没有任何信息输出。

于是定位到grapDLCount文件，尝试注释掉第71行
> result{'text'}   = Encode::decode_utf8( $result{'text'});

后能够工作，故发现是因为从dlsite爬到的work_text信息没有被成功解码。

通过分析这些失败资源的异同，发现原因出于work_text中的`…`字符，也即HTML中的省略符`&hellip;`。
可以通过在前面增加：
`$result{'text'} =~ s/…/.../;`
将`…`替换为三个`.`解决。

顺便伸手求一下爬虫脚本。
